### PR TITLE
Fixed --expires bug

### DIFF
--- a/lib/action/vote.js
+++ b/lib/action/vote.js
@@ -131,7 +131,7 @@ const votesExpired = poll => {
   if (0 < poll.expires) {
     const date = new Date(poll.time);
     date.setSeconds(date.getSeconds() + poll.expires);
-    return date < new Date().getTime();
+    return date < new Date();
   }
   else {
     return false;

--- a/lib/action/vote.js
+++ b/lib/action/vote.js
@@ -131,7 +131,7 @@ const votesExpired = poll => {
   if (0 < poll.expires) {
     const date = new Date(poll.time);
     date.setSeconds(date.getSeconds() + poll.expires);
-    return 0 < (date.getTime() - poll.time);
+    return date < new Date().getTime();
   }
   else {
     return false;


### PR DESCRIPTION
The date comparison was implemented wrong, so that every poll with an
expiration date expired instantly. Should fix #3 